### PR TITLE
Add MVStore-based model loader/generator

### DIFF
--- a/markoverator-core/build.gradle
+++ b/markoverator-core/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    compile 'com.esotericsoftware.kryo:kryo:2.24.0'
     compile 'com.github.rholder.nlp:fast-tag-core:0.1.0'
     compile 'com.github.rholder.nlp:fast-tag-lexicon:0.1.0'
     compile "org.slf4j:slf4j-api:1.7.5"

--- a/markoverator-core/src/main/java/com/github/megallo/markoverator/bigrammer/BigramModelBuilder.java
+++ b/markoverator-core/src/main/java/com/github/megallo/markoverator/bigrammer/BigramModelBuilder.java
@@ -1,12 +1,7 @@
 package com.github.megallo.markoverator.bigrammer;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 import com.github.megallo.markoverator.utils.Pair;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,34 +52,5 @@ public class BigramModelBuilder {
         }
 
         return new BigramModel(fullWordList, forwardCache, backwardCache);
-    }
-
-    /**
-     * Write out the model object to a stream, e.g. a file on disk
-     * @param model a BigramModel object, like the one built by buildModel()
-     * @param outputStream a writeable stream, such as java.io.FileOutputStream
-     */
-    public static void saveModel(BigramModel model, OutputStream outputStream) {
-        if (model == null) {
-            throw new RuntimeException("Refusing to write empty model.");
-        }
-        Kryo kryo = new Kryo();
-        Output output = new Output(outputStream);
-        kryo.writeObject(output, model);
-        output.close();
-    }
-
-    /**
-     * Load a model object from a stream, e.g. a file on disk
-     * @param inputStream readable stream we can read a previously built model from
-     * @return a BigramModel that's ready to load into Bigrammer
-     */
-    public static BigramModel loadModel(InputStream inputStream) {
-        Kryo kryo = new Kryo();
-        Input input = new Input(inputStream);
-        BigramModel model = kryo.readObject(input, BigramModel.class);
-        input.close();
-
-        return model;
     }
 }

--- a/markoverator-core/src/main/java/com/github/megallo/markoverator/storage/BigrammerStorage.java
+++ b/markoverator-core/src/main/java/com/github/megallo/markoverator/storage/BigrammerStorage.java
@@ -1,0 +1,68 @@
+package com.github.megallo.markoverator.storage;
+
+import com.github.megallo.markoverator.utils.Pair;
+
+import java.util.List;
+
+public interface BigrammerStorage {
+    /*
+    // TODO replacing calls in Bigrammer is workable but need further refactoring for more compact storage
+    - model.getFullWordList().size()
+    - model.getFullWordList().get(seed + 1);
+    - model.getForwardCache().containsKey(new Pair(seedWord1, seedWord2))
+    - model.getForwardCache().get(new Pair(word1, word2));
+    - model.getBackwardCache().get(new Pair(word2, word3));
+     */
+
+    /**
+     * Return the size of the full word list. Each corpus word maps to an
+     * integer from 0 to (size - 1).
+     */
+    int getFullWordListSize();
+
+    /**
+     * Return the word from the original corpus that corresponds to the given
+     * index from 0 to the value returned by getFullWordListSize() - 1.
+     *
+     * @param index the integer index of the word
+     * @return the word at the given index
+     */
+    String getByIndex(int index);
+
+    /**
+     * Return a list of all possible index locations for the given word or null
+     * if there are 0 locations.
+     *
+     * @param word the word to search for possible index locations
+     * @return a list of all index locations or null if there are 0
+     */
+    List<Integer> getAllPossibleLocations(String word);
+
+    /**
+     * Returns true if the given word pair exists in the forward chain.
+     *
+     * @param wordPair word pair to check
+     * @return true if the pair exist, false otherwise
+     */
+    boolean containsForwardWordList(Pair wordPair);
+
+    /**
+     * For the given word pair in the forward chain, return all possible words
+     * that might follow it. Higher probability next-words exist with higher
+     * frequency in the returned list.
+     *
+     * @param wordPair a pair of first word followed by second word
+     * @return list of all possible next words that might immediately follow in the chain
+     */
+    List<String> getForwardWordList(Pair wordPair);
+
+    /**
+     * For the given word pair in the backward chain, return all possible words
+     * that might precede it. Higher probability previous-words exist with
+     * higher frequency in the returned list.
+     *
+     * @param wordPair a pair of first word followed by second word
+     * @return list of all possible previous words that might immediately precede in the chain
+     */
+    List<String> getBackwardWordList(Pair wordPair);
+}

--- a/markoverator-core/src/main/java/com/github/megallo/markoverator/storage/MemoryBigrammerStorage.java
+++ b/markoverator-core/src/main/java/com/github/megallo/markoverator/storage/MemoryBigrammerStorage.java
@@ -1,0 +1,66 @@
+package com.github.megallo.markoverator.storage;
+
+import com.github.megallo.markoverator.bigrammer.BigramModel;
+import com.github.megallo.markoverator.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MemoryBigrammerStorage implements BigrammerStorage {
+
+    private final Map<String, List<Integer>> wordIndexMap; // calculated, so not part of the model object
+    private final BigramModel model;
+
+    public MemoryBigrammerStorage(BigramModel model) {
+        this.model = model;
+        this.wordIndexMap = calculateWordIndices();
+    }
+
+    @Override
+    public int getFullWordListSize() {
+        return model.getFullWordList().size();
+    }
+
+    @Override
+    public String getByIndex(int index) {
+        return model.getFullWordList().get(index);
+    }
+
+    @Override
+    public List<Integer> getAllPossibleLocations(String word) {
+        return wordIndexMap.get(word);
+    }
+
+    @Override
+    public boolean containsForwardWordList(Pair key) {
+        return model.getForwardCache().containsKey(key);
+    }
+
+    @Override
+    public List<String> getForwardWordList(Pair key) {
+        return model.getForwardCache().get(key);
+    }
+
+    @Override
+    public List<String> getBackwardWordList(Pair key) {
+        return model.getBackwardCache().get(key);
+    }
+
+    private Map<String, List<Integer>> calculateWordIndices() {
+        Map<String, List<Integer>> wordIndexMap = new HashMap<>();
+
+        // make a list of the indices at which a given word appears
+        for (int i = 0; i < model.getFullWordList().size(); i++) {
+            String word = model.getFullWordList().get(i);
+            if (!wordIndexMap.containsKey(word)) {
+                wordIndexMap.put(word, new ArrayList<>());
+            }
+            wordIndexMap.get(word).add(i);
+            // DELIM could be removed here if space is a concern
+        }
+
+        return wordIndexMap;
+    }
+}

--- a/markoverator-core/src/main/java/com/github/megallo/markoverator/utils/Pair.java
+++ b/markoverator-core/src/main/java/com/github/megallo/markoverator/utils/Pair.java
@@ -1,9 +1,11 @@
 package com.github.megallo.markoverator.utils;
 
+import java.io.Serializable;
+
 /**
  * Serializable pojo
- **/
-public class Pair {
+ */
+public class Pair implements Serializable {
 
     private String first;
     private String second;

--- a/markoverator-core/src/test/java/com/github/megallo/markoverator/bigrammer/BigrammerTest.java
+++ b/markoverator-core/src/test/java/com/github/megallo/markoverator/bigrammer/BigrammerTest.java
@@ -16,6 +16,7 @@
 
 package com.github.megallo.markoverator.bigrammer;
 
+import com.github.megallo.markoverator.storage.MemoryBigrammerStorage;
 import com.github.megallo.markoverator.utils.Lists;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -28,7 +29,7 @@ import static com.github.megallo.markoverator.bigrammer.Bigrammer.DELIM;
 
 public class BigrammerTest {
 
-    static Bigrammer bigrammer;
+    private static Bigrammer bigrammer;
 
     @BeforeClass
     public static void setup() {
@@ -38,7 +39,7 @@ public class BigrammerTest {
                 Arrays.asList("keep", "yer", "!", "boots", "on"),
                 Arrays.asList(".", "I", "reckon")
         ));
-        bigrammer = new Bigrammer(model);
+        bigrammer = new Bigrammer(new MemoryBigrammerStorage(model));
     }
 
     @Test

--- a/markoverator-examples/build.gradle
+++ b/markoverator-examples/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     compile project(':markoverator-core')
+    compile project(':markoverator-kryo')
+    compile project(':markoverator-h2')
     compile project(':markoverator-poet')
 
     compile "org.slf4j:slf4j-simple:1.7.5"

--- a/markoverator-examples/src/main/java/com/github/megallo/markoverator/MarkovGenerator.java
+++ b/markoverator-examples/src/main/java/com/github/megallo/markoverator/MarkovGenerator.java
@@ -19,6 +19,8 @@ package com.github.megallo.markoverator;
 import com.github.megallo.markoverator.bigrammer.BigramModel;
 import com.github.megallo.markoverator.bigrammer.BigramModelBuilder;
 import com.github.megallo.markoverator.bigrammer.Bigrammer;
+import com.github.megallo.markoverator.kryo.utils.KryoModelUtils;
+import com.github.megallo.markoverator.storage.MemoryBigrammerStorage;
 import com.github.megallo.markoverator.utils.TextUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,10 +67,10 @@ public class MarkovGenerator {
         or you can load up a model that you created previously. Use the method that's right for you!
          */
 
-        BigramModel model = mg.buildAndSaveModel(args[0], args[1]);
-//        BigramModel model = mg.loadModelFromFile(args[1]);
+        //BigramModel model = mg.buildAndSaveModel(args[0], args[1]);
+        BigramModel model = mg.loadModelFromFile(args[1]);
 
-        Bigrammer bigrams = new Bigrammer(model);
+        Bigrammer bigrams = new Bigrammer(new MemoryBigrammerStorage(model));
 
         // generate totally random sentences
         for (int i = 0; i < 10; i++) {
@@ -116,7 +118,7 @@ public class MarkovGenerator {
 
         // save the model to a file (not required in order to use it to generate random with the Bigrammer)
         try {
-            BigramModelBuilder.saveModel(model, new FileOutputStream(new File(modelFilePath)));
+            KryoModelUtils.saveModel(model, new FileOutputStream(new File(modelFilePath)));
         } catch (FileNotFoundException e) {
             throw new RuntimeException("Couldn't write model to file " + modelFilePath, e);
         }
@@ -134,7 +136,7 @@ public class MarkovGenerator {
     public BigramModel loadModelFromFile(String modelFilePath) {
         BigramModel model;
         try {
-            model = BigramModelBuilder.loadModel(new FileInputStream(new File(modelFilePath)));
+            model = KryoModelUtils.loadModel(new FileInputStream(new File(modelFilePath)));
         } catch (FileNotFoundException e) {
             throw new RuntimeException("Couldn't find model file at " + modelFilePath, e);
         }

--- a/markoverator-examples/src/main/java/com/github/megallo/markoverator/PoemGenerator.java
+++ b/markoverator-examples/src/main/java/com/github/megallo/markoverator/PoemGenerator.java
@@ -17,9 +17,10 @@
 package com.github.megallo.markoverator;
 
 import com.github.megallo.markoverator.bigrammer.BigramModel;
-import com.github.megallo.markoverator.bigrammer.BigramModelBuilder;
 import com.github.megallo.markoverator.bigrammer.Bigrammer;
+import com.github.megallo.markoverator.kryo.utils.KryoModelUtils;
 import com.github.megallo.markoverator.poet.Poet;
+import com.github.megallo.markoverator.storage.MemoryBigrammerStorage;
 import com.github.megallo.markoverator.utils.TextUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,8 @@ public class PoemGenerator {
     PoemGenerator(String modelFile) throws FileNotFoundException {
         // load an existing model from a file
         // example model creation is shown in MarkovGenerator
-        BigramModel model = BigramModelBuilder.loadModel(new FileInputStream(new File(modelFile)));
-        this.bigrammer = new Bigrammer(model);
+        BigramModel model = KryoModelUtils.loadModel(new FileInputStream(new File(modelFile)));
+        this.bigrammer = new Bigrammer(new MemoryBigrammerStorage(model));
         this.bigrammer.setMaxHalfLength(6); // short and sweet
         poet = new Poet();
     }

--- a/markoverator-h2/build.gradle
+++ b/markoverator-h2/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    compile project(':markoverator-core')
+
+    compile 'com.h2database:h2:2.1.212'
+}

--- a/markoverator-h2/src/main/java/com/github/megallo/markoverator/storage/h2/MVStoreBigrammerStorage.java
+++ b/markoverator-h2/src/main/java/com/github/megallo/markoverator/storage/h2/MVStoreBigrammerStorage.java
@@ -1,0 +1,71 @@
+package com.github.megallo.markoverator.storage.h2;
+
+import com.github.megallo.markoverator.storage.BigrammerStorage;
+import com.github.megallo.markoverator.utils.Pair;
+import org.h2.mvstore.MVStore;
+
+import java.util.List;
+import java.util.Map;
+
+public class MVStoreBigrammerStorage implements BigrammerStorage {
+
+    private final MVStore store;
+
+    private final Map<Integer, String> fullWordList;
+    private final Map<Pair, List<String>> forwardCache;
+    private final Map<Pair, List<String>> backwardCache;
+    private final Map<String, List<Integer>> wordIndex;
+
+    public MVStoreBigrammerStorage(String filename) {
+        this.store = new MVStore.Builder()
+                .fileName(filename)
+                .readOnly()
+                .open();
+
+        // all_words <counter, word>
+        this.fullWordList = store.openMap("fullWordList");
+
+        // forward_chain <word_one, word_two, word_three>
+        this.forwardCache = store.openMap("forwardCache");
+
+        // backward_chain <word_two, word_three, word_one>
+        this.backwardCache = store.openMap("backwardCache");
+
+        // word_index <word, <list of word locations>>
+        this.wordIndex = store.openMap("wordIndex");
+    }
+
+    @Override
+    public int getFullWordListSize() {
+        return fullWordList.size();
+    }
+
+    @Override
+    public String getByIndex(int index) {
+        return fullWordList.get(index);
+    }
+
+    @Override
+    public List<Integer> getAllPossibleLocations(String word) {
+        return wordIndex.get(word);
+    }
+
+    @Override
+    public boolean containsForwardWordList(Pair key) {
+        return forwardCache.containsKey(key);
+    }
+
+    @Override
+    public List<String> getForwardWordList(Pair key) {
+        return forwardCache.get(key);
+    }
+
+    @Override
+    public List<String> getBackwardWordList(Pair key) {
+        return backwardCache.get(key);
+    }
+
+    public String getFileName() {
+        return store.getFileStore().getFileName();
+    }
+}

--- a/markoverator-h2/src/main/java/com/github/megallo/markoverator/storage/h2/MVStoreModelGenerator.java
+++ b/markoverator-h2/src/main/java/com/github/megallo/markoverator/storage/h2/MVStoreModelGenerator.java
@@ -1,0 +1,117 @@
+package com.github.megallo.markoverator.storage.h2;
+
+import com.github.megallo.markoverator.utils.Pair;
+import org.h2.mvstore.MVStore;
+import org.h2.mvstore.MVStoreTool;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static com.github.megallo.markoverator.bigrammer.Bigrammer.DELIM;
+
+public class MVStoreModelGenerator {
+
+    private final MVStore store;
+
+    // all_words <counter, word>
+    private final Map<Integer, String> fullWordList;
+
+    // forward_chain <word_one, word_two, word_three>
+    private final Map<Pair, List<String>> forwardCache;
+
+    // backward_chain <word_two, word_three, word_one>
+    private final Map<Pair, List<String>> backwardCache;
+
+    // word_index <word, <list of word locations>>
+    private final Map<String, List<Integer>> wordIndex;
+
+    private volatile boolean alreadyGenerated = false;
+
+    public MVStoreModelGenerator(String filename) {
+        // don't overwrite existing file
+        if (Files.exists(Paths.get(filename))) {
+            throw new RuntimeException("File already exists: " + filename);
+        }
+
+        this.store = new MVStore.Builder()
+                .fileName(filename)
+                .compress()
+                .open();
+
+        this.fullWordList = store.openMap("fullWordList");
+        this.forwardCache = store.openMap("forwardCache");
+        this.backwardCache = store.openMap("backwardCache");
+        this.wordIndex = store.openMap("wordIndex");
+    }
+
+    public synchronized void generateFromSentences(List<List<String>> sentencesList) {
+        // this is a one time operation
+        if (alreadyGenerated) {
+            throw new RuntimeException("Model has already been generated");
+        }
+
+        // add sentence delimiters to get more natural sentence starts and ends
+        int counter = 0;
+        for (List<String> oneSentence : sentencesList) {
+            fullWordList.put(counter++, DELIM);
+            for (String word : oneSentence) {
+                fullWordList.put(counter++, word);
+            }
+        }
+        fullWordList.put(counter, DELIM); // don't forget the one at the end
+        store.commit();
+
+        // for each triplet
+        //   map of (<w1, w2> -> w3) = generates forward text
+        //   map of (<w2, w3> -> w1) = generates backward text
+
+        for (int i = 0; i < fullWordList.size() - 2; i++) {
+            String w1 = fullWordList.get(i);
+            String w2 = fullWordList.get(i + 1);
+            String w3 = fullWordList.get(i + 2);
+
+            Pair forwardPair = new Pair(w1, w2);
+            Pair backwardPair = new Pair(w2, w3);
+
+            if (!forwardCache.containsKey(forwardPair)) {
+                forwardCache.put(forwardPair, new CopyOnWriteArrayList<>());
+            }
+            forwardCache.get(forwardPair).add(w3);
+
+            if (!backwardCache.containsKey(backwardPair)) {
+                backwardCache.put(backwardPair, new CopyOnWriteArrayList<>());
+            }
+            backwardCache.get(backwardPair).add(w1);
+
+            // update word index to include current word
+            addToWordIndex(w1, i);
+
+            // prevent iteration over ArrayList during serialization outside this loop
+            //store.commit();
+        }
+
+        // update wordIndex for the last 2 values from the loop
+        int index = fullWordList.size() - 2;
+        String word = fullWordList.get(index);
+        addToWordIndex(word, index);
+
+        index = fullWordList.size() - 1;
+        word = fullWordList.get(index);
+        addToWordIndex(word, index);
+
+        // close and compact the file
+        store.close();
+        MVStoreTool.compact(store.getFileStore().getFileName(), true);
+        alreadyGenerated = true;
+    }
+
+    private void addToWordIndex(String word, int index) {
+        if (!wordIndex.containsKey(word)) {
+            wordIndex.put(word, new CopyOnWriteArrayList<>());
+        }
+        wordIndex.get(word).add(index);
+    }
+}

--- a/markoverator-kryo/build.gradle
+++ b/markoverator-kryo/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    compile project(':markoverator-core')
+
+    compile 'com.esotericsoftware.kryo:kryo:2.24.0'
+}

--- a/markoverator-kryo/src/main/java/com/github/megallo/markoverator/kryo/utils/KryoModelUtils.java
+++ b/markoverator-kryo/src/main/java/com/github/megallo/markoverator/kryo/utils/KryoModelUtils.java
@@ -1,0 +1,41 @@
+package com.github.megallo.markoverator.kryo.utils;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.github.megallo.markoverator.bigrammer.BigramModel;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class KryoModelUtils {
+
+    /**
+     * Write out the model object to a stream, e.g. a file on disk
+     * @param model a BigramModel object, like the one built by buildModel()
+     * @param outputStream a writeable stream, such as java.io.FileOutputStream
+     */
+    public static void saveModel(BigramModel model, OutputStream outputStream) {
+        if (model == null) {
+            throw new RuntimeException("Refusing to write empty model.");
+        }
+        Kryo kryo = new Kryo();
+        Output output = new Output(outputStream);
+        kryo.writeObject(output, model);
+        output.close();
+    }
+
+    /**
+     * Load a model object from a stream, e.g. a file on disk
+     * @param inputStream readable stream we can read a previously built model from
+     * @return a BigramModel that's ready to load into Bigrammer
+     */
+    public static BigramModel loadModel(InputStream inputStream) {
+        Kryo kryo = new Kryo();
+        Input input = new Input(inputStream);
+        BigramModel model = kryo.readObject(input, BigramModel.class);
+        input.close();
+
+        return model;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'markoverator'
 include 'markoverator-core',
         'markoverator-examples',
+        'markoverator-h2',
+        'markoverator-kryo',
         'markoverator-poet'


### PR DESCRIPTION
This adds the `markoverator-kryo` and the `markoverator-h2` modules along with some refactoring to get us a low-memory utilization, `MVStore`-based model. Here are some additional highlights:
* Added `BigrammerStorage` interface to encapsulate model functionality
* Replaced direct calls to `BigramModel` with `BigrammerStorage` in `Bigrammer`
* Added MemoryBigrammerStorage implementation as an in-memory `BigrammerStorage`
* Added `MVStoreModelGenerator` for creating `MVStore`-based `BigrammerStorage` models
* Moved word index calculation out of `Bigrammer`
* Moved Kryo serialization/deserialization to `KryoModelUtils`